### PR TITLE
Release V1.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,46 +1,48 @@
 PATH
   remote: .
   specs:
-    omniauth-snapchat (0.1.3)
-      omniauth-oauth2 (~> 1.6)
+    omniauth-snapchat (1.0.0)
+      omniauth-oauth2 (~> 1.8)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    faraday (1.3.0)
-      faraday-net_http (~> 1.0)
-      multipart-post (>= 1.2, < 3)
-      ruby2_keywords
-    faraday-net_http (1.0.1)
-    hashie (4.1.0)
-    jwt (2.2.2)
-    multi_json (1.15.0)
+    faraday (2.7.4)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
+    hashie (5.0.0)
+    jwt (2.7.0)
     multi_xml (0.6.0)
-    multipart-post (2.1.1)
-    oauth2 (1.4.4)
-      faraday (>= 0.8, < 2.0)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
-      multi_json (~> 1.3)
       multi_xml (~> 0.5)
-      rack (>= 1.2, < 3)
-    omniauth (2.0.1)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    omniauth (2.1.1)
       hashie (>= 3.4.6)
-      rack (>= 1.6.2, < 3)
+      rack (>= 2.2.3)
       rack-protection
-    omniauth-oauth2 (1.7.1)
-      oauth2 (~> 1.4)
-      omniauth (>= 1.9, < 3)
-    rack (2.2.3)
-    rack-protection (2.1.0)
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
+    rack (3.0.7)
+    rack-protection (3.0.5)
       rack
-    ruby2_keywords (0.0.2)
+    ruby2_keywords (0.0.5)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
+    version_gem (1.1.2)
 
 PLATFORMS
-  ruby
+  universal-darwin-22
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2)
   omniauth-snapchat!
 
 BUNDLED WITH
-   1.17.3
+   2.2.33

--- a/lib/omniauth/snapchat/version.rb
+++ b/lib/omniauth/snapchat/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Snapchat
-    VERSION = "0.1.3"
+    VERSION = "1.0.0"
   end
 end

--- a/omniauth-snapchat.gemspec
+++ b/omniauth-snapchat.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files`.split("\n")
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_runtime_dependency "omniauth-oauth2", "~> 1.8"
 end

--- a/omniauth-snapchat.gemspec
+++ b/omniauth-snapchat.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split("\n")
 
   spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_runtime_dependency "omniauth-oauth2", "~> 1.6"
+  spec.add_runtime_dependency "omniauth-oauth2", "~> 1.8"
 end


### PR DESCRIPTION
Version 1.0.0.

Omniauth-oauth2 has to be updated to support omniauth 2.0 because newer gems like omniauth-tiktok-oauth2 require a omniauth version greater than 2. This change was made to resolve the conflict with these newer gems.